### PR TITLE
corrected timestamp fetching location

### DIFF
--- a/pycozmo/client.py
+++ b/pycozmo/client.py
@@ -253,7 +253,6 @@ class Client(event.Dispatcher):
 
     def _process_completed_image(self):
         data = self._partial_data[0:self._partial_size]
-
         # The first byte of the image is whether or not it is in color
         is_color_image = data[0] != 0
 
@@ -269,11 +268,12 @@ class Client(event.Dispatcher):
 
         if self.enable_jpeg_decoding:
             image = Image.open(io.BytesIO(data)).convert('RGB')
-
             # Color images need to be resized to the proper resolution
             if is_color_image:
                 size = camera.RESOLUTIONS[self._partial_image_resolution]
-                image = image.resize(size)
+                image = image.resize(size)  
+        else:
+            image = data
 
         self._latest_image = image
         self.last_image_timestamp = self._partial_image_timestamp

--- a/pycozmo/client.py
+++ b/pycozmo/client.py
@@ -222,7 +222,6 @@ class Client(event.Dispatcher):
                 return
             # Discard any previous in-progress image
             self._reset_partial_state()
-            self._partial_image_timestamp = pkt.frame_timestamp
             self._partial_image_id = pkt.image_id
             self._partial_image_encoding = protocol_encoder.ImageEncoding(pkt.image_encoding)
             self._partial_image_resolution = protocol_encoder.ImageResolution(pkt.image_resolution)
@@ -243,6 +242,7 @@ class Client(event.Dispatcher):
         self._partial_data[offset:offset + len(pkt.data)] = np.frombuffer(pkt.data, dtype=np.uint8)
         self._partial_size += len(pkt.data)
         self._last_chunk_id = pkt.chunk_id
+        self._partial_image_timestamp = pkt.frame_timestamp
 
         if pkt.chunk_id == pkt.image_chunk_count - 1:
             self._process_completed_image()

--- a/pycozmo/client.py
+++ b/pycozmo/client.py
@@ -46,7 +46,9 @@ class Client(event.Dispatcher):
                  protocol_log_messages: Optional[list] = None,
                  auto_initialize: bool = True,
                  enable_animations: bool = True,
-                 enable_procedural_face: bool = True) -> None:
+                 enable_procedural_face: bool = True,
+                 enable_jpeg_decoding: bool = True) -> None:
+
         super().__init__()
         # Whether to automatically initialize the robot when connection is established.
         self.auto_initialize = bool(auto_initialize)
@@ -86,6 +88,7 @@ class Client(event.Dispatcher):
         self.client_drop_count = 0
         # Camera state
         self.last_image_timestamp = None
+        self.enable_jpeg_decoding = enable_jpeg_decoding
         # Object state
         self.available_objects = dict()
         self.connected_objects = dict()
@@ -264,12 +267,13 @@ class Client(event.Dispatcher):
             else:
                 data = camera.minigray_to_jpeg(data, width, height)
 
-        image = Image.open(io.BytesIO(data)).convert('RGB')
+        if self.enable_jpeg_decoding:
+            image = Image.open(io.BytesIO(data)).convert('RGB')
 
-        # Color images need to be resized to the proper resolution
-        if is_color_image:
-            size = camera.RESOLUTIONS[self._partial_image_resolution]
-            image = image.resize(size)
+            # Color images need to be resized to the proper resolution
+            if is_color_image:
+                size = camera.RESOLUTIONS[self._partial_image_resolution]
+                image = image.resize(size)
 
         self._latest_image = image
         self.last_image_timestamp = self._partial_image_timestamp

--- a/pycozmo/run.py
+++ b/pycozmo/run.py
@@ -61,7 +61,8 @@ def connect(
         robot_log_level: Optional[str] = None,
         auto_initialize: bool = True,
         enable_animations: bool = True,
-        enable_procedural_face: bool = True) -> client.Client:
+        enable_procedural_face: bool = True,
+        *args, **kwargs) -> client.Client:
 
     setup_basic_logging(log_level=log_level, protocol_log_level=protocol_log_level, robot_log_level=robot_log_level)
 
@@ -70,7 +71,8 @@ def connect(
             protocol_log_messages=protocol_log_messages,
             auto_initialize=auto_initialize,
             enable_animations=enable_animations,
-            enable_procedural_face=enable_procedural_face)
+            enable_procedural_face=enable_procedural_face,
+            *args, **kwargs)
         cli.start()
         cli.connect()
         cli.wait_for_robot()


### PR DESCRIPTION
The timestamp of a given frame should be fetched from the third image chunk, not the first one. Fetching from the first one gives a timestamp equal to zero for each frame, which is not wanted. The proposed change solves this issue, and `cli.last_image_timestamp` gives meaningful values.